### PR TITLE
API documentation fails with Windows line endings

### DIFF
--- a/js/common/modules/org/arangodb/foxx/preprocessor.js
+++ b/js/common/modules/org/arangodb/foxx/preprocessor.js
@@ -81,7 +81,7 @@ Preprocessor = function (input, type) {
     input = coffeeScript.compile(input, {bare: true});
   }
 
-  this.iterator = new ArrayIterator(input.split("\n"));
+  this.iterator = new ArrayIterator(input.replace('\r', '').split("\n"));
   this.inJSDoc = false;
 };
 


### PR DESCRIPTION
I am following the [My First Foxx App](https://docs.arangodb.com/cookbook/FoxxFirstSteps.html) cookbook, and reached the step where API documentation is added to the basic get controller implementation. After completing this step, the API documentation part of the ArangoDB web interface failed with the following message:

    Sorry the code is not documented properly
    "Unable to read api 'todos' from path http://localhost:8529/_db/_system/_admin/aardvark/docu/dev%3Atodos%3Atodos/dev/todos?api_key=false (server returned Internal Error)"

I discovered by experimentation that this error was produced when using Windows (CR/LF) line endings in my todos.js controller file. Switching to Unix line endings fixed the problem.

Suggest this would be a showstopper for a naive programmer.