### PR TITLE
_api/replication/inventory includeSystem parameter

### DIFF
--- a/UnitTests/HttpInterface/api-replication-spec.rb
+++ b/UnitTests/HttpInterface/api-replication-spec.rb
@@ -323,6 +323,21 @@ describe ArangoDB do
 ## inventory
 ################################################################################
 
+      it "checks the initial inventory with the default value for includeSystem" do
+        cmd = api + "/inventory"
+        doc = ArangoDB.log_get("#{prefix}-inventory-system-defaults", cmd, :body => "")
+
+        doc.code.should eq(200)
+        all = doc.parsed_response
+        all.should have_key('collections')
+        all.should have_key('state')
+
+        collections = all["collections"]
+        collections.each { |collection|
+          collection["parameters"]["name"].should_not match(/^_/)
+        }
+      end
+
       it "checks the initial inventory" do
         cmd = api + "/inventory?includeSystem=false"
         doc = ArangoDB.log_get("#{prefix}-inventory", cmd, :body => "")

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1207,7 +1207,7 @@ void RestReplicationHandler::handleCommandInventory () {
   TRI_voc_tick_t tick = TRI_CurrentTickServer();
 
   // include system collections?
-  bool includeSystem = true;
+  bool includeSystem = false;
   bool found;
   const char* value = _request->value("includeSystem", found);
 


### PR DESCRIPTION
The [documentation](https://docs.arangodb.com/HttpReplications/ReplicationDump.html) says includeSystem is false by default but I noticed the opposite is true and there's no test for it.

This PR uses false as default value and adds a test to verify the default value is correct.